### PR TITLE
ci: generate catalog before validate

### DIFF
--- a/.github/workflows/validate-packs.yml
+++ b/.github/workflows/validate-packs.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Build catalog
+        run: |
+          node psycle-expo/scripts/generate_manifest.mjs
+          cp psycle-expo/data/manifest.json catalog.json
       - name: Validate JSON
         run: |
           if [ -x scripts/validate.sh ]; then


### PR DESCRIPTION
Fix Validate & Auto Publish failing: generate catalog.json before jq validation.