### PR TITLE
chore: drop メイン branch filters from workflows

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -3,9 +3,9 @@ name: Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, メイン, fix/question-renderer-safe]
+    branches: [main, fix/question-renderer-safe]
   pull_request:
-    branches: [main, メイン]
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/validate-packs.yml
+++ b/.github/workflows/validate-packs.yml
@@ -1,9 +1,9 @@
 name: Validate & Auto Publish
 on:
   pull_request:
-    branches: [ main, メイン ]
+    branches: [ main ]
   push:
-    branches: [ main, メイン ]
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       track:


### PR DESCRIPTION
## Summary
- Remove legacy メイン branch filters now that default is main

## Testing
- Not run (workflow filter change only)