### PR TITLE
chore: allowlist intentional i18n duplicates

### DIFF
--- a/psycle-expo/scripts/lint-i18n.js
+++ b/psycle-expo/scripts/lint-i18n.js
@@ -18,6 +18,9 @@ const path = require('path');
 const LOCALES_DIR = path.join(__dirname, '..', 'lib', 'locales');
 const BASE_LOCALE = 'ja';
 
+// Keys allowed to have duplicate values (e.g., same UI text appears in multiple places)
+const ALLOW_DUPLICATE_KEYS = new Set(['shop.subscription.restore', 'settings.restorePurchases']);
+
 // Simple placeholder pattern: {{variableName}}
 const PLACEHOLDER_PATTERN = /\{\{[^}]+\}\}/g;
 
@@ -215,7 +218,11 @@ function validate() {
 
     for (const [value, keys] of valueToKeys.entries()) {
       if (keys.length > 1) {
-        warnings.push(`[${localeName}] Duplicate value "${value.substring(0, 30)}..." at: ${keys.join(', ')}`);
+        // Skip if all duplicate keys are in the allowlist
+        const allAllowed = keys.every(k => ALLOW_DUPLICATE_KEYS.has(k));
+        if (!allAllowed) {
+          warnings.push(`[${localeName}] Duplicate value "${value.substring(0, 30)}..." at: ${keys.join(', ')}`);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add `ALLOW_DUPLICATE_KEYS` allowlist for intentional duplicate values
- Keys: `shop.subscription.restore` and `settings.restorePurchases` (same UI text in different locations)
- `npm run i18n:report` now shows 0 warnings instead of 5

## Why
Future maintainers won't be confused by false-positive duplicate warnings for intentionally identical strings.

## Test plan
- [x] `npm run i18n:report` passes with 0 errors and 0 warnings

Generated with [Claude Code](https://claude.com/claude-code)