### PR TITLE
ci: add i18n:report to CI workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,3 +29,8 @@ jobs:
         run: |
           cd psycle-expo
           npx jest --watchman=false
+
+      - name: Validate i18n locales
+        run: |
+          cd psycle-expo
+          npm run i18n:report


### PR DESCRIPTION
## Summary
- Add `npm run i18n:report` step to CI after tests
- Validates locale files for missing keys, placeholder mismatches, ICU errors
- Fails CI if any locale has errors

## Test plan
- [x] Local `npm run i18n:report` passes
- [ ] CI workflow runs successfully

Generated with [Claude Code](https://claude.com/claude-code)