### PR TITLE
chore: clarify workflow roles and prevent duplicate publish paths

### DIFF
--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -1,0 +1,11 @@
+# Workflow Ownership
+
+This repo intentionally separates validation, scheduled publish, and manual publish to avoid duplicate publish paths.
+
+| Workflow file | Trigger(s) | Responsibility |
+| --- | --- | --- |
+| `ci-tests.yml` | `pull_request`, `push` (`main` only), `workflow_dispatch` | Test and content quality checks |
+| `validate-packs.yml` | `pull_request`, `push` (`main` only) | Catalog/pack validation only |
+| `auto-publish.yml` | `schedule` | Weekly automatic publish from queue |
+| `publish-manual.yml` | `workflow_dispatch` | On-demand manual publish |
+| `content-generation.yml` | `schedule`, `workflow_dispatch` | Autonomous content generation |

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,13 +1,7 @@
 name: Auto Publish Packs
 on:
   schedule:
-    - cron: "0 0 * * MON"  # UTC 00:00 = JST 09:00 月曜
-  workflow_dispatch:
-    inputs:
-      track:
-        description: publish track (mental|money|work|all)
-        required: false
-        default: all
+    - cron: "0 0 * * MON"  # UTC 00:00 = JST 09:00 Monday
 permissions:
   contents: write
 concurrency:
@@ -24,13 +18,10 @@ jobs:
           git config user.name "pack-bot"
           git config user.email "bot@users.noreply.github.com"
       - name: run auto publish
-        env:
-          TRACK_INPUT: ${{ github.event.inputs.track }}
         run: |
           set -e
           chmod +x scripts/ops.sh scripts/auto_publish.sh || true
           tracks=(mental money work)
-          if [ -n "${TRACK_INPUT}" ] && [ "${TRACK_INPUT}" != "all" ]; then tracks=("${TRACK_INPUT}"); fi
           for t in "${tracks[@]}"; do
             [ -d "queue/$t" ] && bash scripts/auto_publish.sh "$t" || true
           done

--- a/.github/workflows/validate-packs.yml
+++ b/.github/workflows/validate-packs.yml
@@ -4,18 +4,10 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
-  workflow_dispatch:
-    inputs:
-      track:
-        description: publish track (mental|money|work|all)
-        required: false
-        default: all
-  schedule:
-    - cron: "0 0 * * MON"   # UTC 00:00 = JST 09:00
 permissions:
-  contents: write
+  contents: read
 concurrency:
-  group: validate-and-publish
+  group: validate-packs
   cancel-in-progress: false
 jobs:
   validate:
@@ -35,26 +27,3 @@ jobs:
             echo "scripts/validate.sh not found; running minimal checks"
             jq -e . catalog.json >/dev/null
           fi
-  publish:
-    # 手動or週次だけで動かす（pushでは動かさない）
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y jq
-      - name: git config
-        run: |
-          git config user.name "pack-bot"
-          git config user.email "bot@users.noreply.github.com"
-      - name: Auto publish from queue
-        env:
-          TRACK_INPUT: ${{ github.event.inputs.track }}
-        run: |
-          set -e
-          chmod +x scripts/ops.sh scripts/auto_publish.sh || true
-          tracks=(mental money work)
-          if [ -n "${TRACK_INPUT}" ] && [ "${TRACK_INPUT}" != "all" ]; then tracks=("${TRACK_INPUT}"); fi
-          for t in "${tracks[@]}"; do
-            [ -d "queue/$t" ] && bash scripts/auto_publish.sh "$t" || true
-          done
-# trigger refresh


### PR DESCRIPTION
- document workflow ownership and triggers in .github/workflows/WORKFLOWS.md\n- keep validate-packs focused on validation only\n- keep auto-publish focused on scheduled publishing only\n- leave publish-manual as the only on-demand publish entry point