### PR TITLE
chore: expand content-generation rotation and set workflow permissions

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -20,6 +20,11 @@ on:
           - Work
           - Mental
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
 jobs:
   generate-content:
     runs-on: ubuntu-latest
@@ -50,7 +55,7 @@ jobs:
           if [ "${{ github.event.inputs.genre }}" = "all" ] || [ -z "${{ github.event.inputs.genre }}" ]; then
             # Generate one genre per day in rotation
             DAY_OF_YEAR=$(date +%j)
-            GENRES=("Health" "Social" "Study")
+            GENRES=("Health" "Social" "Study" "Money" "Work" "Mental")
             INDEX=$((DAY_OF_YEAR % ${#GENRES[@]}))
             GENRE=${GENRES[$INDEX]}
             echo "genre=$GENRE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- include Money/Work/Mental in daily rotation when genre=all\n- declare permissions needed by push + gh pr create steps (contents/pull-requests/actions)