### PR TITLE
fix: content-generation Node cache dependency path

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       
-        cache-dependency-path: psycle-expo/package-lock.json
+          cache-dependency-path: psycle-expo/package-lock.json
       - name: Install dependencies
         run: |
           cd psycle-expo


### PR DESCRIPTION
Fix workflow_dispatch failure: setup-node cache couldn't find lockfile at repo root. Point cache-dependency-path to psycle-expo/package-lock.json.