### PR TITLE
fix: restore psycle-billing submodule metadata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "psycle-billing"]
+  path = psycle-billing
+  url = https://github.com/shin2721/psycle-billing.git


### PR DESCRIPTION
pages-build-deployment fails because psycle-billing is tracked as a gitlink (mode 160000) but .gitmodules is missing. This PR restores .gitmodules so CI can initialize submodules reproducibly.