### PR TITLE
chore: add content-generation safety guards

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -25,6 +25,10 @@ permissions:
   pull-requests: write
   actions: read
 
+concurrency:
+  group: autonomous-content-generation
+  cancel-in-progress: false
+
 jobs:
   generate-content:
     runs-on: ubuntu-latest
@@ -45,6 +49,13 @@ jobs:
           cd psycle-expo
           npm ci
       
+      - name: Validate required secrets
+        run: |
+          if [ -z "${{ secrets.GEMINI_API_KEY }}" ]; then
+            echo "::error::Missing required secret: GEMINI_API_KEY"
+            exit 1
+          fi
+
       - name: Setup environment
         run: |
           cd psycle-expo


### PR DESCRIPTION
Add workflow-level concurrency to prevent overlapping content-generation runs and fail fast with a clear error when GEMINI_API_KEY is missing.