### PR TITLE
content(i18n): complete mental unit English (l03-l06)

### DIFF
--- a/psycle-expo/data/lessons/mental_units/index.ts
+++ b/psycle-expo/data/lessons/mental_units/index.ts
@@ -9,6 +9,10 @@ import mental_l06_ja from "./mental_l06.ja.json";
 // English translations (fallback to ja if not available)
 import mental_l01_en from "./mental_l01.en.json";
 import mental_l02_en from "./mental_l02.en.json";
+import mental_l03_en from "./mental_l03.en.json";
+import mental_l04_en from "./mental_l04.en.json";
+import mental_l05_en from "./mental_l05.en.json";
+import mental_l06_en from "./mental_l06.en.json";
 
 // Japanese (base) - always available
 export const mentalData_ja = [
@@ -24,10 +28,10 @@ export const mentalData_ja = [
 export const mentalData_en = [
   ...mental_l01_en,
   ...mental_l02_en,
-  ...mental_l03_ja, // fallback to ja
-  ...mental_l04_ja, // fallback to ja
-  ...mental_l05_ja, // fallback to ja
-  ...mental_l06_ja, // fallback to ja
+  ...mental_l03_en,
+  ...mental_l04_en,
+  ...mental_l05_en,
+  ...mental_l06_en,
 ];
 
 // Default export (ja for backward compatibility)

--- a/psycle-expo/data/lessons/mental_units/mental_l03.en.json
+++ b/psycle-expo/data/lessons/mental_units/mental_l03.en.json
@@ -1,0 +1,379 @@
+[
+    {
+        "id": "mental_l03_001",
+        "type": "swipe_judgment",
+        "question": "5 minutes until the meeting. Heart pounding, palms sweating. The more you tell yourself \"calm down,\" the more anxious you get.",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "Been there",
+            "right": "Never"
+        },
+        "explanation": "Telling yourself \"calm down\" can backfire. The harder you try to suppress emotions, the more your attention fixates on them.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "silver",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "best_for": [
+                "People who struggle with suppressing emotions"
+            ],
+            "limitations": [
+                "Suppression can be effective in some cases (short-term or social situations)"
+            ],
+            "citation_role": "Theoretically explains the backfire mechanism of suppression within an emotion regulation framework",
+            "claim_tags": [
+                "emotion_regulation",
+                "suppression"
+            ]
+        }
+    },
+    {
+        "id": "mental_l03_002",
+        "type": "multiple_choice",
+        "question": "When you feel anxious, what tends to work better than telling yourself \"calm down\"?",
+        "choices": [
+            "Acknowledge it: \"I'm feeling anxious right now\" (labeling)",
+            "Tell yourself \"calm down!\" even harder",
+            "Try not to think about anything"
+        ],
+        "correct_index": 0,
+        "explanation": "Labeling (naming the emotion) can reduce its intensity. Effects vary by individual, and chronic anxiety may require a different approach. (\"Telling yourself harder\" tends to backfire. \"Thinking about nothing\" is often very difficult.)",
+        "actionable_advice": "Tip: Next time you feel anxious, just whisper \"anxiety\" in your mind (10 seconds). Stop immediately if it feels wrong.",
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "silver",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "best_for": [
+                "Everyday mild anxiety",
+                "People wanting to deepen self-understanding"
+            ],
+            "limitations": [
+                "May have limited effect on chronic intense anxiety",
+                "Can intensify rumination in some people"
+            ],
+            "citation_role": "Theoretically explains the mechanism of labeling within an emotion regulation framework",
+            "try_this": "Next time you feel anxious, whisper \"anxiety\" in your mind (10 seconds)",
+            "claim_tags": [
+                "emotion_regulation",
+                "reappraisal"
+            ],
+            "tiny_metric": {
+                "before_prompt": "Current anxiety? (0-10 or high/medium/low)",
+                "after_prompt": "After 10 seconds?",
+                "success_rule": "Even a slight decrease is OK",
+                "stop_rule": "If no change or it increases, retreat for today"
+            },
+            "comparator": {
+                "baseline": "Suppressing with \"calm down\"",
+                "cost": "10 seconds / Low burden"
+            },
+            "fallback": {
+                "when": "If labeling increases your anxiety instead",
+                "next": "Switch to deep breathing (4 sec in, 4 sec out)"
+            }
+        }
+    },
+    {
+        "id": "mental_l03_003",
+        "type": "swipe_judgment",
+        "question": "Reinterpreting your racing heart as \"my body is gearing up for me\" can sometimes improve performance.",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "Seems possible",
+            "right": "Seems unlikely"
+        },
+        "explanation": "This is called \"reappraisal.\" Research shows short-term performance improvements. However, don't push yourself when feeling unwell. It's normal if this doesn't work. Just try once.",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "Jamieson_2012",
+        "evidence_grade": "silver",
+        "expanded_details": {
+            "claim_type": "intervention",
+            "evidence_type": "direct",
+            "best_for": [
+                "Pre-presentation or interview nerves",
+                "Short-term performance situations"
+            ],
+            "limitations": [
+                "Can backfire when physically unwell",
+                "Limited effect on chronic anxiety"
+            ],
+            "citation_role": "Directly supports the performance effects of arousal reappraisal",
+            "claim_tags": [
+                "reappraisal",
+                "arousal",
+                "stress_response",
+                "performance"
+            ],
+            "tiny_metric": {
+                "metric": "Were you able to reframe your racing heart as \"gearing up\" at least once?",
+                "stop_rule": "If you can't remember to try it for 3 days straight, let it go"
+            },
+            "comparator": {
+                "baseline": "Interpreting it negatively: \"Oh no, I'm so nervous\"",
+                "cost": "Low cognitive load (just a reframe)"
+            },
+            "try_this": "Next time you feel nervous, say \"my body is gearing up for me\" for just 10 seconds",
+            "fallback": "If it doesn't fit, switch to deep breathing"
+        }
+    },
+    {
+        "id": "mental_l03_004",
+        "type": "multiple_choice",
+        "question": "Right before a presentation, your palms are drenched in sweat. Which of these would you try?",
+        "choices": [
+            "Reframe it: \"My body is warming up for me\"",
+            "Think: \"This is the worst, I'm nervous again\"",
+            "Ignore the sweaty palms and focus on the content"
+        ],
+        "correct_index": 0,
+        "explanation": "Reframing it as a \"warm-up\" can turn a stress response into a challenge response. It doesn't work for everyone, so don't force it. Just try once. (\"This is the worst\" intensifies anxiety. \"Ignore and focus\" is difficult for anyone.)",
+        "actionable_advice": "Tip: Try this just once tomorrow: when nervous, say \"my body is gearing up for me\" for 10 seconds. Stop immediately if it feels wrong.",
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "Jamieson_2012",
+        "evidence_grade": "silver",
+        "expanded_details": {
+            "claim_type": "intervention",
+            "evidence_type": "direct",
+            "best_for": [
+                "Before presentations, interviews, or exams"
+            ],
+            "limitations": [
+                "Don't push yourself when physically unwell",
+                "May not suit people who resist \"positive thinking\""
+            ],
+            "citation_role": "Supports the practical effects of arousal reappraisal",
+            "try_this": "When nervous, say \"my body is gearing up for me\" for 10 seconds",
+            "claim_tags": [
+                "reappraisal",
+                "arousal",
+                "performance"
+            ],
+            "tiny_metric": {
+                "before_prompt": "Current tension (0-10)",
+                "after_prompt": "Tension after 10 seconds",
+                "success_rule": "Even 1 point down is OK",
+                "stop_rule": "If no change, try a different method"
+            },
+            "comparator": {
+                "baseline": "Blaming yourself: \"I shouldn't be nervous\"",
+                "cost": "10 seconds / Low psychological burden"
+            },
+            "fallback": {
+                "when": "If the reframe feels fake",
+                "next": "Just label it: \"I'm feeling nervous\""
+            }
+        }
+    },
+    {
+        "id": "mental_l03_005",
+        "type": "conversation",
+        "question": "\"Labeling\" vs. \"Reappraisal\" - which seems like a better fit for you?",
+        "your_response_prompt": "Go with your gut",
+        "choices": [
+            "Labeling (just acknowledge \"anxiety\")",
+            "Reappraisal (reframe as \"warming up\")",
+            "Want to try both",
+            "Neither seems to fit"
+        ],
+        "recommended_index": null,
+        "explanation": "Any answer is correct. \"Neither fits\" is valuable information too. It can be the starting point for finding a different approach.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "Supports consideration of individual differences",
+            "claim_tags": [
+                "emotion_regulation",
+                "individual_differences"
+            ]
+        }
+    },
+    {
+        "id": "mental_l03_006",
+        "type": "multiple_choice",
+        "question": "When feeling anxious, what tends to happen if you do \"breathe in for 4 seconds, breathe out for 4 seconds\" three times?",
+        "choices": [
+            "The parasympathetic nervous system activates, helping your heart rate settle",
+            "The sympathetic nervous system ramps up further, increasing anxiety",
+            "Nothing changes"
+        ],
+        "correct_index": 0,
+        "explanation": "Slow breathing stimulates the parasympathetic nervous system. For some people, breathing exercises can actually increase anxiety. It's normal if this doesn't work. Just try once. (\"Sympathetic activation\" happens with rapid breathing. \"Nothing changes\" - while individual differences exist, some change is likely.)",
+        "actionable_advice": "Tip: Try it right now: breathe in for 4 seconds, breathe out for 4 seconds, just once. Skip it if you don't want to.",
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "intervention",
+            "evidence_type": "indirect",
+            "best_for": [
+                "Temporary anxiety",
+                "People who are attuned to bodily sensations"
+            ],
+            "limitations": [
+                "Can backfire for people who struggle with breathing exercises",
+                "Panic attacks require professional support"
+            ],
+            "citation_role": "Indirectly supports the effect of breathing exercises on the autonomic nervous system",
+            "try_this": "Breathe in for 4 seconds, breathe out for 4 seconds, just once",
+            "claim_tags": [
+                "emotion_regulation"
+            ],
+            "tiny_metric": {
+                "before_prompt": "Current anxiety (high/medium/low)",
+                "after_prompt": "After doing it once?",
+                "success_rule": "Even a slight improvement is OK",
+                "stop_rule": "If it feels unpleasant, stop immediately"
+            },
+            "comparator": {
+                "baseline": "Toughing it out",
+                "cost": "8 seconds / Minimal burden"
+            },
+            "fallback": {
+                "when": "If focusing on your breath makes you feel worse",
+                "next": "Shift your attention to sounds around you (5 seconds)"
+            }
+        }
+    },
+    {
+        "id": "mental_l03_007",
+        "type": "swipe_judgment",
+        "question": "Emotion regulation skills are easy to develop for most people with practice.",
+        "is_true": false,
+        "swipe_labels": {
+            "left": "I think so",
+            "right": "I don't think so"
+        },
+        "explanation": "\"Easy for everyone\" is an overstatement. Many people improve with practice, but there are individual differences. For chronic issues, professional support can be effective.",
+        "actionable_advice": null,
+        "difficulty": "hard",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "citation_role": "Theoretically explains individual differences",
+            "claim_tags": [
+                "emotion_regulation",
+                "limitations"
+            ]
+        }
+    },
+    {
+        "id": "mental_l03_008",
+        "type": "multiple_choice",
+        "question": "Of the 3 techniques you learned today (labeling, reappraisal, breathing), which has the lowest barrier to try tomorrow?",
+        "choices": [
+            "Breathing (4 sec in, 4 sec out)",
+            "Labeling (acknowledge \"anxiety\")",
+            "Reappraisal (reframe as \"warming up\")",
+            "All feel too difficult"
+        ],
+        "correct_index": 0,
+        "explanation": "For most people, breathing is the simplest. It doesn't work for everyone, so finding what fits you is what matters. (Labeling and reappraisal are also effective. If \"all feel too difficult,\" exploring a different approach is perfectly OK.)",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "Provides guidance for choosing interventions",
+            "claim_tags": [
+                "breathing",
+                "implementation"
+            ]
+        }
+    },
+    {
+        "id": "mental_l03_009",
+        "type": "conversation",
+        "question": "If you were to try just one thing tomorrow when you feel anxious, what would it be?",
+        "your_response_prompt": "Pick one",
+        "choices": [
+            "Breathing (4 sec in, 4 sec out)",
+            "Labeling (whisper \"anxiety\")",
+            "Reappraisal (reframe as \"warming up\")",
+            "Pass for now"
+        ],
+        "recommended_index": 0,
+        "explanation": "Picking one and trying it is the first step. If it doesn't fit, try another. That's learning too. Just once.",
+        "actionable_advice": "Tip: Tomorrow, just once (10 seconds): try the technique you chose. Stop immediately if it feels wrong.",
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "intervention",
+            "evidence_type": "indirect",
+            "best_for": [
+                "Coping with everyday mild anxiety"
+            ],
+            "limitations": [
+                "Not sufficient for persistent intense anxiety"
+            ],
+            "citation_role": "Presents options for emotion regulation strategies",
+            "try_this": "Try the technique you chose just once (10 seconds)",
+            "claim_tags": [
+                "emotion_regulation"
+            ],
+            "tiny_metric": {
+                "before_prompt": "Anxiety 0-10",
+                "after_prompt": "After 10 seconds 0-10",
+                "success_rule": "Even 1 point down is OK",
+                "stop_rule": "If no change or it increases, retreat"
+            },
+            "comparator": {
+                "baseline": "Doing nothing",
+                "cost": "10 seconds"
+            },
+            "fallback": {
+                "when": "If none of the three worked for you",
+                "next": "Drink water / step away - physically switch things up"
+            }
+        }
+    },
+    {
+        "id": "mental_l03_010",
+        "type": "conversation",
+        "question": "Did the \"anxiety coping techniques\" in this lesson seem useful to you?",
+        "your_response_prompt": "Answer honestly",
+        "choices": [
+            "Seems useful",
+            "Might not be for me",
+            "Not sure yet"
+        ],
+        "recommended_index": null,
+        "explanation": "Any answer is correct. If it \"might not be for you,\" then looking for a different approach is the right move. The process of finding what fits you is itself learning.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Gross_1998",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "Supports consideration of individual differences",
+            "claim_tags": [
+                "individual_differences",
+                "fit"
+            ]
+        }
+    }
+]

--- a/psycle-expo/data/lessons/mental_units/mental_l04.en.json
+++ b/psycle-expo/data/lessons/mental_units/mental_l04.en.json
@@ -1,0 +1,308 @@
+[
+    {
+        "id": "mental_l04_001",
+        "type": "swipe_judgment",
+        "question": "Sunday night. You start thinking about tomorrow, and the same worries loop over and over.",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "Happens often",
+            "right": "Rarely happens"
+        },
+        "explanation": "This is a sign of \"rumination.\" You think you're thinking, but your brain is actually just auto-replaying.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Nolen-Hoeksema_1991",
+        "evidence_grade": "gold",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "direct",
+            "best_for": [
+                "People who want to notice rumination patterns"
+            ],
+            "limitations": [
+                "When feeling deeply down, self-observation itself can be a burden"
+            ],
+            "citation_role": "Supports rumination characteristics and persistence through empirical research",
+            "claim_tags": [
+                "rumination",
+                "repetitive_thinking",
+                "depression"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_002",
+        "type": "multiple_choice",
+        "question": "Which is a characteristic of \"rumination\"?",
+        "choices": [
+            "The same content goes around and around in circles",
+            "The more you think, the more solutions you find",
+            "It naturally subsides over time"
+        ],
+        "correct_index": 0,
+        "explanation": "Rumination looks like \"thinking\" but is actually just repeating the same content. Breaking out usually requires a different approach. (\"Finding solutions\" is problem-solving thinking. \"Naturally subsiding\" is rare.)",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Nolen-Hoeksema_1991",
+        "evidence_grade": "gold",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "direct",
+            "best_for": [
+                "People who want to know the difference between rumination and problem-solving"
+            ],
+            "limitations": [
+                "Not all repetitive thinking is harmful (deliberation is different)"
+            ],
+            "citation_role": "Defines the repetitive nature of rumination",
+            "claim_tags": [
+                "rumination",
+                "repetitive_thinking"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_003",
+        "type": "swipe_judgment",
+        "question": "You have something to do, but you find yourself starting something else instead.",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "Happens often",
+            "right": "Rarely happens"
+        },
+        "explanation": "This is a sign of \"procrastination.\" It's not weakness of will — it's a natural response to avoid discomfort.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Lazarus_1984",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "best_for": [
+                "People who want to notice procrastination patterns"
+            ],
+            "limitations": [
+                "Causes of procrastination are diverse (ADHD, perfectionism, etc.) and can't be generalized"
+            ],
+            "citation_role": "Indirectly explains procrastination as avoidance behavior within cognitive appraisal framework",
+            "claim_tags": [
+                "stress",
+                "coping"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_004",
+        "type": "multiple_choice",
+        "question": "In what situation is procrastination most likely to occur?",
+        "choices": [
+            "When the task involves discomfort (difficult, boring, anxiety-inducing)",
+            "When the task is too easy",
+            "When you have plenty of time"
+        ],
+        "correct_index": 0,
+        "explanation": "Procrastination is \"discomfort avoidance\" behavior. When a task itself feels unpleasant, attention unconsciously shifts elsewhere. (It's more likely with discomfort than when \"too easy\" or \"plenty of time.\")",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "Lazarus_1984",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "best_for": [
+                "People who want to understand the cause of procrastination"
+            ],
+            "limitations": [
+                "Not all procrastination is discomfort avoidance (sometimes it's a priority issue)"
+            ],
+            "citation_role": "Explains procrastination as stress avoidance within cognitive appraisal framework",
+            "claim_tags": [
+                "stress",
+                "coping"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_005",
+        "type": "conversation",
+        "question": "Is there something you've been procrastinating on recently?",
+        "your_response_prompt": "Choose what comes to mind",
+        "choices": [
+            "Work or study related",
+            "Relationships or communication",
+            "Health or lifestyle habits",
+            "Nothing in particular / Can't think of anything"
+        ],
+        "recommended_index": null,
+        "explanation": "Any answer is correct. \"Can't think of anything\" is also a valid answer. If you're not procrastinating, that's great.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Lazarus_1984",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "Supports self-awareness",
+            "claim_tags": [
+                "self_awareness",
+                "stress"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_006",
+        "type": "swipe_judgment",
+        "question": "When about to recall a stressful situation, you deliberately think about something else.",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "I do this often",
+            "right": "Rarely"
+        },
+        "explanation": "This is a sign of \"avoidance.\" It provides short-term relief but can leave problems unresolved long-term.",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "Lazarus_1984",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "best_for": [
+                "People who want to notice avoidance patterns"
+            ],
+            "limitations": [
+                "Avoidance can be effective in some cases (e.g., temporary avoidance right after trauma)"
+            ],
+            "citation_role": "Explains avoidant coping within cognitive appraisal framework",
+            "claim_tags": [
+                "stress",
+                "coping"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_007",
+        "type": "multiple_choice",
+        "question": "Why does \"avoidance\" tend to become a long-term problem?",
+        "choices": [
+            "Problems remain unsolved and anxiety is maintained or intensified",
+            "Problems get solved quickly",
+            "Avoidance itself becomes stressful"
+        ],
+        "correct_index": 0,
+        "explanation": "Avoidance provides short-term relief, but the problem remains. As a result, anxiety tends to persist. (\"Solved quickly\" doesn't happen with avoidance. \"Avoidance itself being stressful\" is a secondary issue.)",
+        "actionable_advice": null,
+        "difficulty": "hard",
+        "xp": 5,
+        "source_id": "Lazarus_1984",
+        "evidence_grade": "silver",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "best_for": [
+                "People who want to understand the long-term impact of avoidance"
+            ],
+            "limitations": [
+                "Not all avoidance is problematic (strategic avoidance can be appropriate)"
+            ],
+            "citation_role": "Explains long-term effects of avoidant coping in stress research context",
+            "claim_tags": [
+                "stress",
+                "coping"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_008",
+        "type": "conversation",
+        "question": "Of the 3 signs you learned today (rumination, procrastination, avoidance), which fits you most?",
+        "your_response_prompt": "Choose based on your gut feeling",
+        "choices": [
+            "Rumination (same worries looping)",
+            "Procrastination (putting off what needs to be done)",
+            "Avoidance (trying not to think about it)",
+            "None of them apply"
+        ],
+        "recommended_index": null,
+        "explanation": "Any answer is correct. \"None apply\" is also valid. Simply noticing your patterns is a meaningful first step.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Nolen-Hoeksema_1991",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "Supports pattern recognition",
+            "claim_tags": [
+                "self_awareness",
+                "pattern_recognition"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_009",
+        "type": "multiple_choice",
+        "question": "What do \"rumination,\" \"procrastination,\" and \"avoidance\" have in common?",
+        "choices": [
+            "They all serve to temporarily escape discomfort",
+            "They're caused by weak willpower",
+            "They're problems that should be fixed immediately"
+        ],
+        "correct_index": 0,
+        "explanation": "All three function as \"discomfort avoidance.\" Rather than blaming yourself, noticing the pattern is the first step. (\"Weak willpower\" is a misconception. \"Fix immediately\" tends to backfire.)",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "Nolen-Hoeksema_1991",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "best_for": [
+                "People who want to understand common ground across patterns"
+            ],
+            "limitations": [
+                "Grouping all three too closely can obscure each one's unique coping strategies"
+            ],
+            "citation_role": "Suggests common function across rumination, procrastination, and avoidance",
+            "claim_tags": [
+                "rumination",
+                "stress",
+                "coping"
+            ]
+        }
+    },
+    {
+        "id": "mental_l04_010",
+        "type": "conversation",
+        "question": "Did you notice any of your own patterns in this lesson?",
+        "your_response_prompt": "Answer honestly",
+        "choices": [
+            "I had some insights",
+            "I already knew this",
+            "I'm not sure"
+        ],
+        "recommended_index": null,
+        "explanation": "Any answer is correct. \"Already knew\" means it was a good review. \"Not sure\" means a different approach might work better for you.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "Nolen-Hoeksema_1991",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "Supports consideration of individual differences",
+            "claim_tags": [
+                "individual_differences",
+                "fit"
+            ]
+        }
+    }
+]

--- a/psycle-expo/data/lessons/mental_units/mental_l05.en.json
+++ b/psycle-expo/data/lessons/mental_units/mental_l05.en.json
@@ -1,0 +1,154 @@
+[
+  {
+    "id": "mental_l05_001",
+    "type": "swipe_judgment",
+    "question": "2 AM. Tomorrow's meeting slides are only half done. The moment you think \"I'll never make it,\" anxiety spikes even more.",
+    "is_true": true,
+    "swipe_labels": {
+      "left": "Happens often",
+      "right": "Rarely happens"
+    },
+    "explanation": "This is a classic \"catastrophic thinking\" example. The prediction \"I won't make it\" races ahead of reality, amplifying anxiety. *This lesson introduces coping methods for mild anxiety. If you experience suicidal thoughts or self-harm tendencies, please consult a professional support service rather than relying on an app.",
+    "difficulty": "easy",
+    "xp": 5,
+    "evidence_grade": "silver"
+  },
+  {
+    "id": "mental_l05_002",
+    "type": "multiple_choice",
+    "question": "When extreme predictions like \"I'll definitely fail\" or \"It's all over\" pop into your head, what's the most effective response?",
+    "choices": [
+      "Ask \"Is that really true?\" and look for evidence",
+      "Tell yourself \"Stop thinking about it\"",
+      "Just distract yourself"
+    ],
+    "correct_index": 0,
+    "explanation": "\"Evidence-checking\" works well for catastrophic thinking. Rather than trying to eliminate the thought, regaining a realistic perspective is key.",
+    "difficulty": "medium",
+    "xp": 5,
+    "evidence_grade": "silver"
+  },
+  {
+    "id": "mental_l05_003",
+    "type": "conversation",
+    "question": "Have you recently felt anxious imagining the \"worst-case scenario\"?",
+    "your_response_prompt": "Try to recall how you felt at that time",
+    "choices": [
+      "Often",
+      "Sometimes",
+      "Rarely"
+    ],
+    "recommended_index": null,
+    "explanation": "Any answer is a normal response. Our brains are wired to predict danger, so imagining negative outcomes is natural.",
+    "difficulty": "easy",
+    "xp": 5,
+    "evidence_grade": "bronze"
+  },
+  {
+    "id": "mental_l05_004",
+    "type": "multiple_choice",
+    "question": "Before a presentation, you think \"I'm going to fail for sure.\" How would you change this thought pattern?",
+    "choices": [
+      "Remind yourself \"I've succeeded in the past too\"",
+      "Just accept it and say \"It's fine even if I fail\"",
+      "Tell yourself \"I'll definitely succeed\""
+    ],
+    "correct_index": 0,
+    "explanation": "Rather than swinging from one extreme to another, finding a balanced perspective is important. Past experience provides realistic evidence.",
+    "difficulty": "medium",
+    "xp": 5,
+    "evidence_grade": "silver"
+  },
+  {
+    "id": "mental_l05_005",
+    "type": "swipe_judgment",
+    "question": "Catastrophic thinking needs to be \"completely eliminated\"",
+    "is_true": false,
+    "swipe_labels": {
+      "left": "I think so",
+      "right": "I don't think so"
+    },
+    "explanation": "You don't need to eliminate it completely. What matters is \"noticing it and adding a realistic perspective.\"",
+    "difficulty": "medium",
+    "xp": 5,
+    "evidence_grade": "bronze"
+  },
+  {
+    "id": "mental_l05_006",
+    "type": "conversation",
+    "question": "When you catch yourself thinking about the \"worst case,\" how do you cope?",
+    "your_response_prompt": "Reflect on your usual behavior",
+    "choices": [
+      "Try not to think about it",
+      "Talk to friends or family",
+      "Think of realistic solutions"
+    ],
+    "recommended_index": 2,
+    "explanation": "Each method can be effective at times, but thinking of realistic solutions can transform anxiety into action.",
+    "difficulty": "easy",
+    "xp": 5,
+    "evidence_grade": "bronze"
+  },
+  {
+    "id": "mental_l05_007",
+    "type": "multiple_choice",
+    "question": "When is catastrophic thinking most likely to occur?",
+    "choices": [
+      "When tired or sleep-deprived",
+      "When feeling energetic and in good shape",
+      "Time of day doesn't matter"
+    ],
+    "correct_index": 0,
+    "explanation": "Fatigue and sleep deprivation reduce judgment and make negative thinking more likely. Physical health management is an important countermeasure too.",
+    "difficulty": "medium",
+    "xp": 5,
+    "evidence_grade": "silver"
+  },
+  {
+    "id": "mental_l05_008",
+    "type": "conversation",
+    "question": "If you were to try the \"evidence-checking\" method you learned today tomorrow?",
+    "your_response_prompt": "What situation would you use it in?",
+    "choices": [
+      "When feeling pressured at work",
+      "When feeling anxious about relationships",
+      "Can't think of a specific situation yet"
+    ],
+    "recommended_index": null,
+    "explanation": "It works in any situation. We recommend starting with small anxieties first.",
+    "difficulty": "easy",
+    "xp": 5,
+    "evidence_grade": "bronze"
+  },
+  {
+    "id": "mental_l05_009",
+    "type": "multiple_choice",
+    "question": "What's the most important thing in dealing with catastrophic thinking?",
+    "choices": [
+      "Completely controlling your thoughts",
+      "Regaining a realistic perspective",
+      "Thinking positively"
+    ],
+    "correct_index": 1,
+    "explanation": "Rather than complete control or forced positive thinking, having a realistic and balanced perspective is what matters.",
+    "difficulty": "hard",
+    "xp": 5,
+    "evidence_grade": "gold"
+  },
+  {
+    "id": "mental_l05_010",
+    "type": "conversation",
+    "question": "Was what you learned in this lesson likely to be useful for you?",
+    "your_response_prompt": "Please share your honest impression",
+    "choices": [
+      "Very likely to be useful",
+      "Somewhat useful",
+      "Probably not useful"
+    ],
+    "recommended_index": null,
+    "explanation": "Every impression is valuable. Different methods work for different people, so finding the approach that fits you is what matters.",
+    "difficulty": "easy",
+    "xp": 5,
+    "evidence_grade": "bronze"
+  }
+]

--- a/psycle-expo/data/lessons/mental_units/mental_l06.en.json
+++ b/psycle-expo/data/lessons/mental_units/mental_l06.en.json
@@ -1,0 +1,329 @@
+[
+    {
+        "id": "mental_l06_001",
+        "type": "swipe_judgment",
+        "question": "\"80 points isn't good enough. It's meaningless unless it's 100.\"",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "Happens often",
+            "right": "Rarely happens"
+        },
+        "explanation": "This is a classic example of \"perfectionism.\" Aiming for perfection isn't bad in itself, but seeing \"anything less than 100 as failure\" can push you into a corner. *This lesson deepens understanding of perfectionism. If you experience suicidal thoughts or self-harm tendencies, please consult a professional support service rather than relying on an app.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "direct",
+            "best_for": [
+                "Self-awareness of perfectionist tendencies"
+            ],
+            "limitations": [
+                "High standards can lead to achievement in some cases"
+            ],
+            "citation_role": "Explains cognitive patterns of perfectionism",
+            "claim_tags": [
+                "完璧主義",
+                "認知パターン"
+            ]
+        }
+    },
+    {
+        "id": "mental_l06_002",
+        "type": "multiple_choice",
+        "question": "What tendency is often seen in people with strong perfectionism?",
+        "choices": [
+            "Becoming anxious about \"what if I fail\" before even starting",
+            "Not worrying about failure and moving on",
+            "Setting low goals to feel safe"
+        ],
+        "correct_index": 0,
+        "explanation": "People with perfectionist tendencies are reported to easily fall into a \"can't get started\" state due to fear of failure.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "best_for": [
+                "Understanding the relationship between perfectionism and behavioral inhibition"
+            ],
+            "limitations": [
+                "Individual differences are large"
+            ],
+            "citation_role": "Explains the connection between perfectionism and anxiety",
+            "claim_tags": [
+                "完璧主義",
+                "不安",
+                "行動抑制"
+            ]
+        }
+    },
+    {
+        "id": "mental_l06_003",
+        "type": "swipe_judgment",
+        "question": "\"I can't feel satisfied with what I've done\"",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "Happens often",
+            "right": "Rarely happens"
+        },
+        "explanation": "Any answer is a normal response. Having high standards can drive growth, but going too far can lead to exhaustion.",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "citation_role": "Explains the dual nature of high standards",
+            "claim_tags": [
+                "完璧主義",
+                "自己評価"
+            ]
+        }
+    },
+    {
+        "id": "mental_l06_004",
+        "type": "multiple_choice",
+        "question": "What's an effective way to \"moderately ease\" perfectionism?",
+        "choices": [
+            "Give yourself permission: \"70 points is OK too\"",
+            "Tell yourself \"Don't aim for perfection\"",
+            "Try not to have any goals"
+        ],
+        "correct_index": 0,
+        "explanation": "\"Widening your acceptable range\" tends to lower the barrier to action. You don't need to completely eliminate perfectionism.",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "silver",
+        "expanded_details": {
+            "claim_type": "intervention",
+            "evidence_type": "direct",
+            "best_for": [
+                "People whose perfectionism stops them from taking action"
+            ],
+            "limitations": [
+                "May backfire in situations requiring high standards"
+            ],
+            "citation_role": "As a cognitive restructuring technique",
+            "try_this": "Before today's first task, say \"70 points is OK\" then start",
+            "claim_tags": [
+                "完璧主義",
+                "認知的再構成",
+                "許容範囲"
+            ],
+            "tiny_metric": {
+                "before_prompt": "Anxiety before starting the task (1-10)",
+                "after_prompt": "Satisfaction after completing the task (1-10)",
+                "success_rule": "Anxiety drops by 3+ or you managed to start the task",
+                "stop_rule": "If anxiety increases instead"
+            },
+            "comparator": {
+                "baseline": "Your usual approach of aiming for perfection",
+                "cost": "Same or less time and effort"
+            },
+            "fallback": {
+                "when": "If you can't accept \"70 points is OK\"",
+                "next": "Try \"just 5 minutes\" by setting a time limit"
+            }
+        }
+    },
+    {
+        "id": "mental_l06_005",
+        "type": "multiple_choice",
+        "question": "Should perfectionism be \"completely eliminated\"?",
+        "choices": [
+            "No, being able to flexibly adjust is what matters",
+            "Yes, perfectionism is nothing but harmful",
+            "Hard to say either way"
+        ],
+        "correct_index": 0,
+        "explanation": "Perfectionism has a \"healthy side\" too — high standards can lead to achievement. The problem arises when flexibility is lost.",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "silver",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "citation_role": "Distinguishes adaptive and maladaptive perfectionism",
+            "claim_tags": [
+                "完璧主義",
+                "柔軟性",
+                "適応的"
+            ]
+        }
+    },
+    {
+        "id": "mental_l06_006",
+        "type": "conversation",
+        "question": "Have you ever thought \"If I can't do it perfectly, it's better not to do it at all\"?",
+        "your_response_prompt": "Try to recall what situation it was",
+        "choices": [
+            "Often",
+            "Sometimes",
+            "Rarely"
+        ],
+        "recommended_index": null,
+        "explanation": "This is a pattern called \"all-or-nothing thinking.\" Even when not perfect, \"doing it\" can build experience over time.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "As an example of dichotomous thinking",
+            "claim_tags": [
+                "完璧主義",
+                "二分法思考",
+                "回避"
+            ]
+        }
+    },
+    {
+        "id": "mental_l06_007",
+        "type": "swipe_judgment",
+        "question": "Perfectionism can lead to procrastination",
+        "is_true": true,
+        "swipe_labels": {
+            "left": "I think so",
+            "right": "I don't think so"
+        },
+        "explanation": "Research suggests a link between perfectionism and procrastination. \"Failure avoidance\" can lead to avoiding action altogether.",
+        "actionable_advice": null,
+        "difficulty": "medium",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "citation_role": "Explains the relationship between perfectionism and procrastination",
+            "claim_tags": [
+                "完璧主義",
+                "先延ばし",
+                "失敗回避"
+            ]
+        }
+    },
+    {
+        "id": "mental_l06_008",
+        "type": "multiple_choice",
+        "question": "What's the most important thing in dealing with perfectionism?",
+        "choices": [
+            "Having flexibility and widening your acceptable range",
+            "Completely eliminating perfectionism",
+            "Not having any goals"
+        ],
+        "correct_index": 0,
+        "explanation": "Rather than \"eliminating\" perfectionism, becoming able to \"flexibly adjust\" is key. Being able to change your standards based on the situation matters.",
+        "actionable_advice": null,
+        "difficulty": "hard",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "gold",
+        "expanded_details": {
+            "claim_type": "theory",
+            "evidence_type": "theoretical",
+            "best_for": [
+                "Considering how to live with perfectionism"
+            ],
+            "limitations": [
+                "Becoming flexible doesn't happen overnight"
+            ],
+            "citation_role": "Recommendation based on meta-analysis",
+            "claim_tags": [
+                "完璧主義",
+                "柔軟性",
+                "対処法"
+            ]
+        }
+    },
+    {
+        "id": "mental_l06_009",
+        "type": "conversation",
+        "question": "If you were to try the \"70 points is OK\" mindset you learned today tomorrow?",
+        "your_response_prompt": "What situation would you try it in?",
+        "choices": [
+            "Work or study tasks",
+            "Housework or daily chores",
+            "Can't think of anything specific yet"
+        ],
+        "recommended_index": 0,
+        "explanation": "Any situation is worth trying. We recommend starting with small tasks — practicing \"moving forward even if it's not perfect.\"",
+        "actionable_advice": "Try saying \"70 points is enough\" three times before your first task tomorrow",
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "intervention",
+            "evidence_type": "indirect",
+            "best_for": [
+                "People who tend to be perfectionistic about daily tasks"
+            ],
+            "limitations": [
+                "Use caution when applying to important tasks"
+            ],
+            "citation_role": "Bridge to practice",
+            "try_this": "Say \"70 points is OK\" out loud before your first morning task",
+            "claim_tags": [
+                "完璧主義",
+                "実践",
+                "行動変容"
+            ],
+            "tiny_metric": {
+                "before_prompt": "Hesitation before starting task (1-10)",
+                "after_prompt": "How you feel after starting (1-10)",
+                "success_rule": "Managed to start without hesitation",
+                "stop_rule": "If stress increases instead"
+            },
+            "comparator": {
+                "baseline": "Your usual approach",
+                "cost": "A few seconds of speaking"
+            },
+            "fallback": {
+                "when": "If you can't accept \"70 points\"",
+                "next": "Start with \"80 points\" instead"
+            }
+        }
+    },
+    {
+        "id": "mental_l06_010",
+        "type": "conversation",
+        "question": "Was what you learned in this lesson likely to be useful for you?",
+        "your_response_prompt": "Please share your honest impression",
+        "choices": [
+            "Very likely to be useful",
+            "Somewhat useful",
+            "Probably not useful"
+        ],
+        "recommended_index": null,
+        "explanation": "Every impression is valuable. How you deal with perfectionism varies from person to person. Taking things at your own pace is what matters.",
+        "actionable_advice": null,
+        "difficulty": "easy",
+        "xp": 5,
+        "source_id": "smith_2016_perfectionism",
+        "evidence_grade": "bronze",
+        "expanded_details": {
+            "claim_type": "observation",
+            "evidence_type": "indirect",
+            "citation_role": "Promotes reflection",
+            "claim_tags": [
+                "振り返り",
+                "自己認識"
+            ]
+        }
+    }
+]


### PR DESCRIPTION
## Summary
- Add English translations for `mental_l03` through `mental_l06` (40 questions total)
- Auto-generated `index.ts` via `gen-lesson-locale-index.js` — no manual editing
- **All 6 mental lessons now have en + ja**

## Validation
```
Lessons with translations: 6
Total errors: 0
Status: PASS
```

## Test plan
- [x] `npm run content:i18n:check` passes (gen + diff + structure validation)
- [ ] CI workflow passes

Generated with [Claude Code](https://claude.com/claude-code)