### PR TITLE
docs: add i18n, submodule, and Pages runbooks

### DIFF
--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -13,3 +13,6 @@ This repo intentionally separates validation, scheduled publish, and manual publ
 ## Runbooks
 
 - Content generation: `RUNBOOK_CONTENT_GENERATION.md`
+- i18n: `../docs/RUNBOOK_I18N.md`
+- psycle-billing submodule: `../docs/RUNBOOK_SUBMODULE_PSYCLE_BILLING.md`
+- Pages re-enable decision: `../docs/PAGES_REENABLE_DECISION.md`

--- a/docs/PAGES_REENABLE_DECISION.md
+++ b/docs/PAGES_REENABLE_DECISION.md
@@ -1,0 +1,20 @@
+# Pages Re-enable Decision
+
+## Purpose
+Capture the decision path for re-enabling GitHub Pages without reintroducing CI noise.
+
+## Current Status
+- Pages is disabled.
+- The previous failure was caused by the private `psycle-billing` submodule.
+
+## Decision Options
+1. Keep Pages disabled.
+2. Re-enable Pages using a custom Actions deploy that can access private submodules.
+3. Re-enable Pages after making `psycle-billing` public.
+
+## Recommended Path
+Use a custom Actions deploy with a read token for private submodules. This avoids changing repo visibility.
+
+## Notes
+- If Pages is re-enabled, set the source branch to `main` and confirm deployments are green.
+- Avoid enabling Pages without a validated deploy workflow.

--- a/docs/RUNBOOK_I18N.md
+++ b/docs/RUNBOOK_I18N.md
@@ -1,0 +1,42 @@
+# i18n Runbook
+
+## Purpose
+Standardize the workflow for adding or updating localized lesson files so index files and validation stay consistent.
+
+## Scope
+This runbook covers lesson JSON files under `psycle-expo/data/lessons/**` and the locale index/validation scripts.
+
+## Preconditions
+1. You have a clean working tree.
+2. You know which unit and lesson IDs you are updating.
+3. You can run Node scripts locally.
+
+## Add or Update Lesson Locales
+1. Add or update the lesson JSON files.
+2. Regenerate locale indices.
+3. Validate locale coverage.
+4. Commit only the intended files.
+
+## Commands
+```bash
+cd psycle-expo
+node scripts/gen-lesson-locale-index.js
+node scripts/validate-lesson-locales.js --check
+cd ..
+```
+
+## Files Typically Changed
+- `psycle-expo/data/lessons/<unit>_units/<lesson>.ja.json`
+- `psycle-expo/data/lessons/<unit>_units/<lesson>.en.json`
+- `psycle-expo/data/lessons/<unit>_units/index.ts`
+
+## Review Checklist
+1. Locale validation passes.
+2. New `index.ts` changes align with the files you added.
+3. No unrelated lesson files changed.
+
+## Common Failures
+1. Validation fails due to missing locale.
+   - Fix: add the missing locale file and re-run the scripts.
+2. Index files missing updates.
+   - Fix: re-run `gen-lesson-locale-index.js` and commit the updated index files.

--- a/docs/RUNBOOK_SUBMODULE_PSYCLE_BILLING.md
+++ b/docs/RUNBOOK_SUBMODULE_PSYCLE_BILLING.md
@@ -1,0 +1,32 @@
+# psycle-billing Submodule Runbook
+
+## Purpose
+Document how to work with the `psycle-billing` private submodule to avoid clone and CI failures.
+
+## Current State
+- `psycle-billing` is a private GitHub repo.
+- The main repo tracks it as a submodule via `.gitmodules`.
+
+## Preconditions
+1. You have access to `shin2721/psycle-billing`.
+2. Your GitHub credentials can read private repos.
+
+## Local Clone
+```bash
+git submodule sync --recursive
+git submodule update --init --recursive
+```
+
+## CI Requirements
+1. The CI token must be able to read `shin2721/psycle-billing`.
+2. If using GitHub Actions, ensure the token has access to that private repo.
+
+## Common Failure
+- Error: `No url found for submodule path 'psycle-billing' in .gitmodules`
+  - Fix: ensure `.gitmodules` exists and includes the correct URL.
+- Error: `repository not found` during checkout
+  - Fix: provide a token with read access or adjust repo visibility.
+
+## Change Policy
+1. If the submodule URL changes, update `.gitmodules` and run `git submodule sync`.
+2. Avoid converting to a normal directory without a migration plan.


### PR DESCRIPTION
Add i18n, psycle-billing submodule, and Pages re-enable runbooks, and link them from WORKFLOWS.md.