### PR TITLE
docs: add i18n PR template and tighten content-generation runbook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/i18n.md
+++ b/.github/PULL_REQUEST_TEMPLATE/i18n.md
@@ -1,0 +1,18 @@
+## Summary
+- [ ] 追加/更新した翻訳ファイルを列挙した
+- [ ] 影響ユニット（mental/health/money/social/study/work）を明記した
+
+## Changed files
+- [ ] `psycle-expo/data/lessons/**/**/*.en.json`（必要分）
+- [ ] `psycle-expo/data/lessons/**/index.ts`（genで更新）
+- [ ] その他（あれば）
+
+## Validation (paste outputs)
+- [ ] `cd psycle-expo && node scripts/gen-lesson-locale-index.js`
+- [ ] `cd psycle-expo && node scripts/validate-lesson-locales.js --check`
+- [ ] `cd psycle-expo && npm run content:i18n:check`
+
+## Quality checklist
+- [ ] プレースホルダ不整合なし（例: `{{count}}`）
+- [ ] 選択肢数・構造の差異なし
+- [ ] フォールバック仕様（requested -> en -> ja）を壊していない

--- a/.github/workflows/RUNBOOK_CONTENT_GENERATION.md
+++ b/.github/workflows/RUNBOOK_CONTENT_GENERATION.md
@@ -47,3 +47,15 @@ Run the Autonomous Content Generation workflow in a repeatable, low-risk way and
 ## Operational Notes
 1. Concurrency is enforced. If a run is in progress, new runs will queue.
 2. Cancel a run from the Actions UI if it is no longer needed.
+
+## Logging
+- 実行ログ確認: GitHub Actions run URL（workflow run詳細）
+- 失敗時は `Setup Node.js` / `Generate` / `Create PR` の3ステップを優先確認
+- 記録対象: run URL, commit SHA, 失敗ステップ名, 再実行有無
+
+## Quality Gate (minimum)
+- 生成後に以下がPASSであること
+  - `node scripts/gen-lesson-locale-index.js`
+  - `node scripts/validate-lesson-locales.js --check`
+  - `npm run content:i18n:check`
+- 自動PR作成時は差分が「対象ユニットの翻訳 + index再生成」に閉じていること


### PR DESCRIPTION
Add i18n PR template, add a short billing entry in README, and extend the content-generation runbook with logging + quality gates.