### PR TITLE
docs: Add Claude workspace guidance for Japanese responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides workspace-level guidance for Claude Code in this repository.
 
+## 応答言語
+
+すべての応答は日本語で行うこと。コミットメッセージやPRタイトルなど、英語が慣習的に使われる箇所は英語のままでよい。
+
 ## Always Use Latest Psycle Branch
 
 Always sync the repository from the current session's working tree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,11 @@ This file provides workspace-level guidance for Claude Code in this repository.
 
 すべての応答は日本語で行うこと。コミットメッセージやPRタイトルなど、英語が慣習的に使われる箇所は英語のままでよい。
 
+## 実行ルール
+
+- ユーザーの明示的な許可なくコマンドやスクリプトを実行しないこと。必ず事前に確認を取る。
+- 実行が許可された場合、変更が発生したらその場でコミットとプッシュまで一連で行うこと。
+
 ## Always Use Latest Psycle Branch
 
 Always sync the repository from the current session's working tree.


### PR DESCRIPTION
## Summary

Updated `CLAUDE.md` to add workspace-level guidance for Claude Code operations in this repository.

## Changes

Added two new sections to the Claude workspace configuration:

1. **応答言語 (Response Language)**: Specifies that all responses should be in Japanese, with exceptions for commit messages and PR titles where English is conventional.

2. **実行ルール (Execution Rules)**: Establishes safety guidelines:
   - Commands and scripts must not be executed without explicit user permission
   - When execution is approved and changes occur, commits and pushes should be completed immediately as part of the same workflow

## Notes

- This is a documentation-only change with no impact on application code
- No testing required

https://claude.ai/code/session_0179wgbeLnu5BsQKRYnKhiTf